### PR TITLE
Python27 fix

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -21,8 +21,6 @@ from distutils.command.clean import clean
 _info_fname = pjoin(os.path.dirname(__file__), 'nipype', 'info.py')
 INFO_VARS = {}
 exec(open(_info_fname, 'rt').read(), {}, INFO_VARS)
-if sys.version_info < (2, 7):
-    INFO_VARS['REQUIRES'].append('ordereddict')
 
 DOC_BUILD_DIR = os.path.join('doc', '_build', 'html')
 DOC_DOCTREES_DIR = os.path.join('doc', '_build', 'doctrees')

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -116,9 +116,7 @@ info = None
 pklfile = '%s'
 batchdir = '%s'
 try:
-    if sys.version_info < (2, 7):
-        from ordereddict import OrderedDict
-    else:
+    if not sys.version_info < (2, 7):
         from collections import OrderedDict
     config_dict=%s
     config.update_config(config_dict)


### PR DESCRIPTION
Fix for pipeline plugins when using python 2.7.  Also prevents exception from getting lost in some situations.
