### PR TITLE
DOC: Explains how subject_id is used in the workflow

### DIFF
--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -105,6 +105,17 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
     Outpus::
            postdatasink_outputspec.subject_id : name of the datasinked output folder in the subjects directory
 
+    Note:
+    The input subject_id is not passed to the commands in the workflow. Commands
+    that require subject_id are reading implicit inputs from 
+    {SUBJECTS_DIR}/{subject_id}. For those commands the subject_id is set to the
+    default value and SUBJECTS_DIR is set to the node directory. The implicit
+    inputs are then copied to the node directory in order to mimic a SUBJECTS_DIR
+    structure. For example, if the command implicitly reads in brainmask.mgz, the
+    interface would copy that input file to 
+    {node_dir}/{subject_id}/mri/brainmask.mgz and set SUBJECTS_DIR to node_dir. 
+    The workflow only uses the input subject_id to datasink the outputs to 
+    {subjects_dir}/{subject_id}.
     """
     reconall = pe.Workflow(name=name)
 


### PR DESCRIPTION
I added an explanation of how the subject_id is used in the workflow. You could set the subject_id for the commands to the workflow's subject_id, but it would only change the directory structure in the node directories. In the end, the workflow only uses the input subject_id to datasink the outputs to {subjects_dir}/{subject_id}.